### PR TITLE
#150497874 Generic Search Recipe

### DIFF
--- a/server/controllers/recipes.js
+++ b/server/controllers/recipes.js
@@ -278,7 +278,7 @@ export const searchByIngredients = (req, res) => {
  * @exports searchAll
  * @param  {obj} req request object
  * @param  {obj} res result object
- * @return {obj}  newUser object
+ * @return {obj}  object
  */
 export const searchAll = (req, res) => {
   let results;

--- a/tests/2-recipes.js
+++ b/tests/2-recipes.js
@@ -122,6 +122,129 @@ describe('/GET Search recipe by ingredient', () => {
         done();
       });
   });
+
+  it('should return 0 recipes when search by \'garri\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?ingredients=garri')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(0);
+        done();
+      });
+  });
+
+  it('should return 1 recipes when search by \'leaves\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?ingredients=leaves')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(1);
+        done();
+      });
+  });
+
+  it('should return 1 recipes when search by \'soup\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?ingredients=maggi')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(1);
+        done();
+      });
+  });
+});
+
+
+describe('/GET Search recipe by valid anything (Generic search)', () => {
+  it('should return 1 recipe when search by \'Ewedu+Soup\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?search=Ewedu+Soup')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(1);
+        done();
+      });
+  });
+
+  it('should return 3 recipes when search by \'water\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?search=water')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(3);
+        done();
+      });
+  });
+
+  it('should return 2 recipes when search by \'rice\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?search=rice')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(2);
+        done();
+      });
+  });
+
+  it('should return 1 recipes when search by ' +
+  '\'createrecipetester@test.com\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?search=createrecipetester@test.com')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(1);
+        done();
+      });
+  });
+
+  it('should return 1 recipes when search by ' +
+  '\'createREcipetester\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?search=createREcipetester')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(1);
+        done();
+      });
+  });
+
+  it('should return 0 recipes when search by ' +
+  '\'createreipetester\'', (done) => {
+    chai.request(server)
+      .get('/api/v1/recipes?search=createreipetester')
+      .set('Accept', 'application/json')
+      .set('x-access-token', token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.success).to.equal(true);
+        expect(res.body.data.length).to.equal(0);
+        done();
+      });
+  });
 });
 
 


### PR DESCRIPTION
#### What does this PR do?
 - Search recipe by Recipe name, ingredients or name of user all from one query
#### Description of Task to be completed?
- Create searchAll function in recipes controller
- Assign GET `/api/v1/recipes?search=searchterm` endpoint
- Assign searchAll function to route
#### How should this be manually tested?
- Clone this repo
- Install dependencies `npm i`
- Test api route above with POSTMAN
#### Any background context you want to provide?
This API endpoint depends on signup, signup and create recipe endpoints, run `git log` for details on these endpoints
#### What are the relevant pivotal tracker stories?
#150497874
